### PR TITLE
Fix containerd runtime.

### DIFF
--- a/example/agent.hcl
+++ b/example/agent.hcl
@@ -3,6 +3,6 @@ log_level = "INFO"
 plugin "containerd-driver" {
   config {
     enabled = true
-    containerd_runtime = "io.containerd.runtime.v1.linux"
+    containerd_runtime = "io.containerd.runc.v2"
   }
 }


### PR DESCRIPTION
The correct values for `v1` and `v2` shim are:

````
v1: io.containerd.runc.v1
v2: io.containerd.runc.v2
````