### PR TITLE
Ability to launch nomad job in read-only mode.

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -42,6 +42,10 @@ func (d *Driver) createContainer(image containerd.Image, containerName, containe
 		opts = append(opts, oci.WithPrivileged)
 	}
 
+	if config.ReadOnlyRootfs {
+		opts = append(opts, oci.WithRootFSReadonly())
+	}
+
 	if len(config.CapAdd) > 0 {
 		opts = append(opts, oci.WithAddedCapabilities(config.CapAdd))
 	}

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -69,12 +69,13 @@ var (
 	// this is used to validate the configuration specified for the plugin
 	// when a job is submitted.
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
-		"image":      hclspec.NewAttr("image", "string", true),
-		"command":    hclspec.NewAttr("command", "string", false),
-		"args":       hclspec.NewAttr("args", "list(string)", false),
-		"cap_add":    hclspec.NewAttr("cap_add", "list(string)", false),
-		"cap_drop":   hclspec.NewAttr("cap_drop", "list(string)", false),
-		"privileged": hclspec.NewAttr("privileged", "bool", false),
+		"image":           hclspec.NewAttr("image", "string", true),
+		"command":         hclspec.NewAttr("command", "string", false),
+		"args":            hclspec.NewAttr("args", "list(string)", false),
+		"cap_add":         hclspec.NewAttr("cap_add", "list(string)", false),
+		"cap_drop":        hclspec.NewAttr("cap_drop", "list(string)", false),
+		"privileged":      hclspec.NewAttr("privileged", "bool", false),
+		"readonly_rootfs": hclspec.NewAttr("readonly_rootfs", "bool", false),
 	})
 
 	// capabilities indicates what optional features this driver supports
@@ -97,12 +98,13 @@ type Config struct {
 // TaskConfig contains configuration information for a task that runs with
 // this plugin
 type TaskConfig struct {
-	Image      string   `codec:"image"`
-	Command    string   `codec:"command"`
-	Args       []string `codec:"args"`
-	CapAdd     []string `codec:"cap_add"`
-	CapDrop    []string `codec:"cap_drop"`
-	Privileged bool     `codec:"privileged"`
+	Image          string   `codec:"image"`
+	Command        string   `codec:"command"`
+	Args           []string `codec:"args"`
+	CapAdd         []string `codec:"cap_add"`
+	CapDrop        []string `codec:"cap_drop"`
+	Privileged     bool     `codec:"privileged"`
+	ReadOnlyRootfs bool     `codec:"readonly_rootfs"`
 }
 
 // TaskState is the runtime state which is encoded in the handle returned to


### PR DESCRIPTION
Tested both `privileged` and `readonly_rootfs` flags.

Sample job:

```
job "ubuntu" {
  datacenters = ["dc1"]

  group "ubuntu-group" {
    task "ubuntu-task" {
      driver = "containerd-driver"

      config {
        image    = "docker.io/library/ubuntu:16.04"
        command  = "sleep"
        args     = ["600s"]
	privileged = true
	readonly_rootfs = true
      }

      resources {
        cpu    = 500
        memory = 256
        network {
          mbits = 10
        }
      }
    }
  }
}
```

```
$ nomad job run ubuntu.nomad
```

```
$ nomad alloc exec -i -t 7bc18922 /bin/bash
```

In the container shell:

1) Privileged container running with full capabilities.

```
root@smahajan-VirtualBox:/# capsh --print
Current: = cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,37+eip
Bounding set =cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,37
Securebits: 00/0x0/1'b0
 secure-noroot: no (unlocked)
 secure-no-suid-fixup: no (unlocked)
 secure-keep-caps: no (unlocked)
uid=0(root)
gid=0(root)
groups=
```

2) Read-only container root filesystem.

```
root@smahajan-VirtualBox:/# cd home
root@smahajan-VirtualBox:/home# ls
root@smahajan-VirtualBox:/home# echo hello > hello.txt
bash: hello.txt: Read-only file system
```