### PR TITLE
Bind mount ${NOMAD_ALLOC_DIR} into the container.

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -41,7 +41,7 @@ func (d *Driver) pullImage(imageName string) (containerd.Image, error) {
 	return d.client.Pull(d.ctxContainerd, imageName, containerd.WithPullUnpack)
 }
 
-func (d *Driver) createContainer(image containerd.Image, containerName, containerSnapshotName, containerdRuntime, netnsPath, secretsDir, taskDir string, env []string, config *TaskConfig) (containerd.Container, error) {
+func (d *Driver) createContainer(image containerd.Image, containerName, containerSnapshotName, containerdRuntime, netnsPath, secretsDir, taskDir, allocDir string, env []string, config *TaskConfig) (containerd.Container, error) {
 	if config.Command == "" && len(config.Args) > 0 {
 		return nil, fmt.Errorf("Command is empty. Cannot set --args without --command.")
 	}
@@ -133,6 +133,12 @@ func (d *Driver) createContainer(image containerd.Image, containerName, containe
 	if taskDir != "" {
 		taskMount := buildMountpoint("bind", "/local", taskDir, []string{"rbind", "ro"})
 		mounts = append(mounts, taskMount)
+	}
+
+	// Setup "/alloc" (NOMAD_ALLOC_DIR) in the container.
+	if allocDir != "" {
+		allocMount := buildMountpoint("bind", "/alloc", allocDir, []string{"rbind", "ro"})
+		mounts = append(mounts, allocMount)
 	}
 
 	if len(mounts) > 0 {

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -357,7 +357,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	// Setup environment variables.
 	var env []string
-	var secretsDir, taskDir string
+	var secretsDir, taskDir, allocDir string
 	for key, val := range cfg.Env {
 		if skipOverride(key) {
 			continue
@@ -368,6 +368,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		if key == "NOMAD_TASK_DIR" {
 			taskDir = val
 		}
+		if key == "NOMAD_ALLOC_DIR" {
+			allocDir = val
+		}
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
@@ -377,7 +380,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		netnsPath = cfg.NetworkIsolation.Path
 	}
 
-	container, err := d.createContainer(image, containerName, containerSnapshotName, d.config.ContainerdRuntime, netnsPath, secretsDir, taskDir, env, &driverConfig)
+	container, err := d.createContainer(image, containerName, containerSnapshotName, d.config.ContainerdRuntime, netnsPath, secretsDir, taskDir, allocDir, env, &driverConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error in creating container: %v", err)
 	}


### PR DESCRIPTION
Looks like `docker` task driver mounts all 3 (`/alloc`, `/local` and `/secrets`) into the container.

```
            "Binds": [
                "/opt/nomad/data/alloc/<alloc_id>/alloc:/alloc",
                "/opt/nomad/data/alloc/<alloc_id>/adaas/local:/local",
                "/opt/nomad/data/alloc/<alloc_id>/adaas/secrets:/secrets"
            ],
```