### PR TITLE
Fix issues in containerd-driver

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -45,14 +45,14 @@ type ContainerConfig struct {
 }
 
 func (d *Driver) isContainerdRunning() (bool, error) {
-	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 15*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 30*time.Second)
 	defer cancel()
 
 	return d.client.IsServing(ctxWithTimeout)
 }
 
 func (d *Driver) getContainerdVersion() (containerd.Version, error) {
-	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 15*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 30*time.Second)
 	defer cancel()
 
 	return d.client.Version(ctxWithTimeout)
@@ -196,7 +196,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 		opts = append(opts, oci.WithLinuxNamespace(specs.LinuxNamespace{Type: specs.NetworkNamespace, Path: containerConfig.NetworkNamespacePath}))
 	}
 
-	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 15*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 30*time.Second)
 	defer cancel()
 
 	return d.client.NewContainer(
@@ -219,7 +219,7 @@ func buildMountpoint(mountType, mountTarget, mountSource string, mountOptions []
 }
 
 func (d *Driver) loadContainer(id string) (containerd.Container, error) {
-	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 15*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 30*time.Second)
 	defer cancel()
 
 	return d.client.LoadContainer(ctxWithTimeout, id)
@@ -249,7 +249,7 @@ func openFIFO(path string) (*os.File, error) {
 }
 
 func (d *Driver) getTask(container containerd.Container) (containerd.Task, error) {
-	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 15*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 30*time.Second)
 	defer cancel()
 
 	return container.Task(ctxWithTimeout, cio.Load)

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -307,14 +307,10 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	}
 
 	isRunning, err := d.isContainerdRunning()
-	if err != nil {
-		d.logger.Error("Error in buildFingerprint(): failed to get containerd status: %v", err)
-		fp.Health = drivers.HealthStateUndetected
-		fp.HealthDescription = "Undetected"
-		return fp
-	}
-
-	if !isRunning {
+	if err != nil || !isRunning {
+		if err != nil {
+			d.logger.Error("Error in buildFingerprint(): failed to get containerd status: %v", err)
+		}
 		fp.Health = drivers.HealthStateUnhealthy
 		fp.HealthDescription = "Unhealthy"
 		return fp

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -309,7 +309,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	isRunning, err := d.isContainerdRunning()
 	if err != nil || !isRunning {
 		if err != nil {
-			d.logger.Error("Error in buildFingerprint(): failed to get containerd status: %v", err)
+			d.logger.Error(fmt.Sprintf("Error in buildFingerprint(): failed to get containerd status: %v\n", err))
 		}
 		fp.Health = drivers.HealthStateUnhealthy
 		fp.HealthDescription = "Unhealthy"
@@ -319,7 +319,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	// Get containerd version
 	version, err := d.getContainerdVersion()
 	if err != nil {
-		d.logger.Warn("Error in buildFingerprint(): failed to get containerd version: %v", err)
+		d.logger.Warn(fmt.Sprintf("Error in buildFingerprint(): failed to get containerd version: %v\n", err))
 		return fp
 	}
 
@@ -394,13 +394,13 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("Error in creating container: %v", err)
 	}
 
-	d.logger.Info(fmt.Sprintf("Successfully created container with name: %s", containerName))
+	d.logger.Info(fmt.Sprintf("Successfully created container with name: %s\n", containerName))
 	task, err := d.createTask(container, cfg.StdoutPath, cfg.StderrPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error in creating task: %v", err)
 	}
 
-	d.logger.Info(fmt.Sprintf("Successfully created task with ID: %s", task.ID()))
+	d.logger.Info(fmt.Sprintf("Successfully created task with ID: %s\n", task.ID()))
 
 	h := &taskHandle{
 		taskConfig:     cfg,
@@ -499,7 +499,7 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 		go h.run(d.ctxContainerd)
 	}
 
-	d.logger.Info(fmt.Sprintf("Task with ID: %s recovered successfully.", handle.Config.ID))
+	d.logger.Info(fmt.Sprintf("Task with ID: %s recovered successfully.\n", handle.Config.ID))
 	return nil
 }
 
@@ -605,7 +605,7 @@ func (d *Driver) TaskStats(ctx context.Context, taskID string, interval time.Dur
 		if err != nil {
 			d.logger.Warn("Error parsing driver stats interval, fallback on default interval")
 		} else {
-			msg := fmt.Sprintf("Overriding client stats interval: %v with driver stats interval: %v", interval, d.config.StatsInterval)
+			msg := fmt.Sprintf("Overriding client stats interval: %v with driver stats interval: %v\n", interval, d.config.StatsInterval)
 			d.logger.Debug(msg)
 			interval = statsInterval
 		}

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -529,17 +529,15 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 	exitStatusCh, err := handle.task.Wait(ctxWithTimeout)
 	if err != nil {
 		result = &drivers.ExitResult{
-			Err: fmt.Errorf("executor: error waiting on process: %v", err),
+			ExitCode: 255,
+			Err:      fmt.Errorf("executor: error waiting on process: %v", err),
 		}
 	} else {
 		status := <-exitStatusCh
 		code, _, err := status.Result()
-		if err != nil {
-			d.logger.Error(err.Error())
-			return
-		}
 		result = &drivers.ExitResult{
 			ExitCode: int(code),
+			Err:      err,
 		}
 	}
 

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -309,7 +309,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	isRunning, err := d.isContainerdRunning()
 	if err != nil || !isRunning {
 		if err != nil {
-			d.logger.Error(fmt.Sprintf("Error in buildFingerprint(): failed to get containerd status: %v\n", err))
+			d.logger.Error("Error in buildFingerprint(): failed to get containerd status", "error", err)
 		}
 		fp.Health = drivers.HealthStateUnhealthy
 		fp.HealthDescription = "Unhealthy"
@@ -319,7 +319,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	// Get containerd version
 	version, err := d.getContainerdVersion()
 	if err != nil {
-		d.logger.Warn(fmt.Sprintf("Error in buildFingerprint(): failed to get containerd version: %v\n", err))
+		d.logger.Warn("Error in buildFingerprint(): failed to get containerd version:", "error", err)
 		return fp
 	}
 

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -523,10 +523,7 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 	defer close(ch)
 	var result *drivers.ExitResult
 
-	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 30*time.Second)
-	defer cancel()
-
-	exitStatusCh, err := handle.task.Wait(ctxWithTimeout)
+	exitStatusCh, err := handle.task.Wait(d.ctxContainerd)
 	if err != nil {
 		result = &drivers.ExitResult{
 			ExitCode: 255,


### PR DESCRIPTION
We found 3 issues while testing failure scenarios in `containerd` i.e. If `containerd` goes down (or restarts), how does `nomad-driver-containerd` handles that situation:

Issues:

1. When `containerd-driver` makes a gRPC call to `containerd` e.g. during [`fingerprinting operation`](https://github.com/Roblox/nomad-driver-containerd/blob/master/containerd/containerd.go#L46), a context timeout must be set. Right now, without the timeout, if `containerd` goes down, that call never returns leaving `containerd-driver` in a hung state.


2. handleWait() throwing a nil pointer exception: Sending an [`empty return`](https://github.com/Roblox/nomad-driver-containerd/blob/master/containerd/driver.go#L532) to `nomad client` results in nomad client dereferencing a nil pointer which results in a nil pointer exception.
3. Issue in recovering task if nomad/nomad-driver-containerd restarts. This might also be related to the networking error we are observing

```
Dec 17 18:47:14 ip-10-102-98-114 nomad[27030]:  client.driver_mgr.containerd-driver: HELLO: RecoverTask: Failed to decode driver config: driver=containerd-driver @module=containerd-driver timestamp=2020-12-17T18:47:14.167Z
Dec 17 18:47:14 ip-10-102-98-114 nomad[27030]: client.alloc_runner.task_runner: error recovering task; cleaning up: alloc_id=2d6b365f-cc89-b230-2af9-a37ccbf0f6c8 task=adaas-task error="rpc error: code = Unknown desc = failed to decode driver config: EOF" task_id=2d6b365f-cc89-b230-2af9-a37ccbf0f6c8/adaas-task/43e03bbd
Dec 17 18:47:14 ip-10-102-98-114 nomad[27030]:  client.alloc_runner.task_runner: error destroying unrecoverable task: alloc_id=2d6b365f-cc89-b230-2af9-a37ccbf0f6c8 task=adaas-task error="rpc error: code = Unknown desc = task not found for given id" task_id=2d6b365f-cc89-b230-2af9-a37ccbf0f6c8/adaas-task/43e03bbd
2020-12-16T17:20:11-08:00  Setup Failure  failed to setup alloc: pre-run hook "network" failed: failed to create network for alloc: open /var/run/netns/d30ebc57-6ed4-9dc0-c604-e2fea98257f1: operation not permitted
```


This PR addresses (1) and (2). I will open a separate PR for Issue (3).