### PR TITLE
Add task name as part of container name

### DIFF
--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -35,7 +35,6 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 	"github.com/hashicorp/nomad/plugins/shared/structs"
-	"github.com/moby/moby/pkg/namesgenerator"
 )
 
 const (
@@ -368,15 +367,14 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	handle := drivers.NewTaskHandle(taskHandleVersion)
 	handle.Config = cfg
 
-	// Generate a random container name using docker namesgenerator package.
-	// https://github.com/moby/moby/blob/master/pkg/namesgenerator/names-generator.go
-	containerName := cfg.AllocID[:8] + "_" + namesgenerator.GetRandomName(1)
+	// https://www.nomadproject.io/docs/drivers/docker#container-name
+	containerName := cfg.Name + "-" + cfg.AllocID
 	containerConfig.ContainerName = containerName
 
 	var err error
 	containerConfig.Image, err = d.pullImage(driverConfig.Image)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error in pulling image: %v", err)
+		return nil, nil, fmt.Errorf("Error in pulling image %s: %v", driverConfig.Image, err)
 	}
 
 	d.logger.Info(fmt.Sprintf("Successfully pulled %s image\n", containerConfig.Image.Name()))

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/hashicorp/nomad v0.10.1
 	github.com/hashicorp/nomad/api v0.0.0-20191203164002-b31573ae7206 // indirect
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b // indirect
-	github.com/moby/moby v1.13.1
 	github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618 // indirect
 	github.com/opencontainers/runc v1.0.0-rc8.0.20190611121236-6cc515888830 // indirect
 	github.com/opencontainers/runtime-spec v1.0.2


### PR DESCRIPTION

the container name generated by containerd-driver  do not contain the task name. It is hard to recognize without query the job first. docker driver do contain the task name as part of container name. 

This PR follow the definition in https://www.nomadproject.io/docs/drivers/docker#container-name

```
Nomad creates a container after pulling an image. Containers are named {taskName}-{allocId}. This is necessary in order to place more than one container from the same task on a host (e.g. with count > 1). This also means that each container's name is unique across the cluster.

This is not configurable.
```

The container name after apply this PR:

```
$ ctr -n nomad c ls                                                                                                 
CONTAINER                                    IMAGE                             RUNTIME                                                                                                                                                        
test-2a00fa59-0a27-55ac-e546-a87cbff58ecd    docker.io/library/ubuntu:20.04    io.containerd.runc.v2  
$ ctr -n nomad t ls                                                                                                                                                                                                                        
TASK                                         PID       STATUS    
test-2a00fa59-0a27-55ac-e546-a87cbff58ecd    395792    RUNNING 
```

and the docker naming like this:

```
$ docker ps
CONTAINER ID   IMAGE          COMMAND        CREATED         STATUS        PORTS     NAMES
8e09db1dd79b   ubuntu:20.04   "sleep 600s"   2 seconds ago   Up 1 second             test-c54c5f82-7e2d-10fb-baba-cd092b482280
```