### PR TITLE
Add support for arm64.

### DIFF
--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -1,0 +1,23 @@
+BINARY ?= containerd-driver
+ifndef $(GOLANG)
+    GOLANG=$(shell which go)
+    export GOLANG
+endif
+
+export GOARCH=arm64
+export GO111MODULE=on
+export GOOS=linux
+
+default: build
+
+.PHONY: clean
+clean:
+	rm -f $(BINARY)
+
+.PHONY: build
+build:
+	$(GOLANG) build -o $(BINARY) .
+
+.PHONY: test
+test:
+	./tests/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ $ cd nomad-driver-containerd
 $ make build (This will build your containerd-driver binary)
 ```
 
+If you want to compile for `arm64`, you can run:
+
+```
+make -f Makefile.arm64
+```
+
 ## Screencast
 [![asciicast](https://asciinema.org/a/348173.svg)](https://asciinema.org/a/348173)
 


### PR DESCRIPTION
Fixes #61 

More details [`here`](https://github.com/Roblox/nomad-driver-containerd/issues/61#issuecomment-770035665)