### PR TITLE
Add support for pids_limit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ More detailed instructions are in the [`example README.md`](https://github.com/R
 | **entrypoint** | []string | no | A string list overriding the image's entrypoint. |
 | **cwd** | string | no | Specify the current working directory for your container process. If the directory does not exist, one will be created for you. |
 | **privileged** | bool | no | Run container in privileged mode. Your container will have all linux capabilities when running in privileged mode. |
+| **pids_limit** | int64 | no | An integer value that specifies the pid limit for the container. Defaults to unlimited. |
 | **host_dns** | bool | no | Default (`true`). By default, a container launched using `containerd-driver` will use host `/etc/resolv.conf`. This is similar to [`docker behavior`](https://docs.docker.com/config/containers/container-networking/#dns-services). However, if you don't want to use host DNS, you can turn off this flag by setting `host_dns=false`. |
 | **seccomp** | bool | no | Enable default seccomp profile. List of [`allowed syscalls`](https://github.com/containerd/containerd/blob/master/contrib/seccomp/seccomp_default.go#L51-L395). |
 | **seccomp_profile** | string | no | Path to custom seccomp profile. `seccomp` must be set to `true` in order to use `seccomp_profile`. The default `docker` seccomp profile found [`here`](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json) can be used as a reference, and modified to create a custom seccomp profile. |

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -113,6 +113,11 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 		opts = append(opts, oci.WithPrivileged)
 	}
 
+	// WithPidsLimit sets the container's pid limit or maximum
+	if config.PidsLimit > 0 {
+		opts = append(opts, oci.WithPidsLimit(config.PidsLimit))
+	}
+
 	if !config.Seccomp && config.SeccompProfile != "" {
 		return nil, fmt.Errorf("seccomp must be set to true, if using a custom seccomp_profile.")
 	}

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -98,6 +98,7 @@ var (
 		"cwd":        hclspec.NewAttr("cwd", "string", false),
 		"devices":    hclspec.NewAttr("devices", "list(string)", false),
 		"privileged": hclspec.NewAttr("privileged", "bool", false),
+		"pids_limit": hclspec.NewAttr("pids_limit", "number", false),
 		"host_dns": hclspec.NewDefault(
 			hclspec.NewAttr("host_dns", "bool", false),
 			hclspec.NewLiteral("true"),
@@ -160,6 +161,7 @@ type TaskConfig struct {
 	Seccomp        bool     `codec:"seccomp"`
 	SeccompProfile string   `codec:"seccomp_profile"`
 	Privileged     bool     `codec:"privileged"`
+	PidsLimit      int64    `codec:"pids_limit"`
 	HostDNS        bool     `codec:"host_dns"`
 	ExtraHosts     []string `codec:"extra_hosts"`
 	Entrypoint     []string `codec:"entrypoint"`


### PR DESCRIPTION
This will provide protection against fork bombs.