### PR TITLE
Add pid_mode to enable host pid namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ More detailed instructions are in the [`example README.md`](https://github.com/R
 | **cwd** | string | no | Specify the current working directory for your container process. If the directory does not exist, one will be created for you. |
 | **privileged** | bool | no | Run container in privileged mode. Your container will have all linux capabilities when running in privileged mode. |
 | **pids_limit** | int64 | no | An integer value that specifies the pid limit for the container. Defaults to unlimited. |
+| **pid_mode** | string | no | `host` or not set (default). Set to `host` to share the PID namespace with the host. |
 | **hostname** | string | no | The hostname to assign to the container. When launching more than one of a task (using `count`) with this option set, every container the task starts will have the same hostname. |
 | **host_dns** | bool | no | Default (`true`). By default, a container launched using `containerd-driver` will use host `/etc/resolv.conf`. This is similar to [`docker behavior`](https://docs.docker.com/config/containers/container-networking/#dns-services). However, if you don't want to use host DNS, you can turn off this flag by setting `host_dns=false`. |
 | **seccomp** | bool | no | Enable default seccomp profile. List of [`allowed syscalls`](https://github.com/containerd/containerd/blob/master/contrib/seccomp/seccomp_default.go#L51-L395). |

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -20,6 +20,7 @@ package containerd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	etchosts "github.com/Roblox/nomad-driver-containerd/etchosts"
@@ -153,6 +154,14 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 	// WithPidsLimit sets the container's pid limit or maximum
 	if config.PidsLimit > 0 {
 		opts = append(opts, oci.WithPidsLimit(config.PidsLimit))
+	}
+
+	if config.PidMode != "" {
+		if strings.ToLower(config.PidMode) != "host" {
+			return nil, fmt.Errorf("Invalid pid_mode. Set pid_mode=host to enable host pid namespace.")
+		} else {
+			opts = append(opts, oci.WithHostNamespace(specs.PIDNamespace))
+		}
 	}
 
 	// Set sysctls

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -104,6 +104,7 @@ var (
 		"devices":    hclspec.NewAttr("devices", "list(string)", false),
 		"privileged": hclspec.NewAttr("privileged", "bool", false),
 		"pids_limit": hclspec.NewAttr("pids_limit", "number", false),
+		"pid_mode":   hclspec.NewAttr("pid_mode", "string", false),
 		"hostname":   hclspec.NewAttr("hostname", "string", false),
 		"host_dns": hclspec.NewDefault(
 			hclspec.NewAttr("host_dns", "bool", false),
@@ -185,6 +186,7 @@ type TaskConfig struct {
 	Sysctl           hclutils.MapStrStr `codec:"sysctl"`
 	Privileged       bool               `codec:"privileged"`
 	PidsLimit        int64              `codec:"pids_limit"`
+	PidMode          string             `codec:"pid_mode"`
 	Hostname         string             `codec:"hostname"`
 	HostDNS          bool               `codec:"host_dns"`
 	ImagePullTimeout string             `codec:"image_pull_timeout"`


### PR DESCRIPTION
Equivalent docker driver option: https://www.nomadproject.io/docs/drivers/docker#pid_mode

Signed-off-by: Shishir Mahajan <smahajan@roblox.com>