### PR TITLE
Add support for shm_size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ More detailed instructions are in the [`example README.md`](https://github.com/R
 | **host_dns** | bool | no | Default (`true`). By default, a container launched using `containerd-driver` will use host `/etc/resolv.conf`. This is similar to [`docker behavior`](https://docs.docker.com/config/containers/container-networking/#dns-services). However, if you don't want to use host DNS, you can turn off this flag by setting `host_dns=false`. |
 | **seccomp** | bool | no | Enable default seccomp profile. List of [`allowed syscalls`](https://github.com/containerd/containerd/blob/master/contrib/seccomp/seccomp_default.go#L51-L395). |
 | **seccomp_profile** | string | no | Path to custom seccomp profile. `seccomp` must be set to `true` in order to use `seccomp_profile`. The default `docker` seccomp profile found [`here`](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json) can be used as a reference, and modified to create a custom seccomp profile. |
+| **shm_size** | string | no | Size of /dev/shm e.g. "128M" if you want 128 MB of /dev/shm. |
 | **sysctl** | map[string]string | no | A key-value map of sysctl configurations to set to the containers on start. |
 | **readonly_rootfs** | bool | no | Container root filesystem will be read-only. |
 | **host_network** | bool | no | Enable host network. This is equivalent to `--net=host` in docker. |

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	refdocker "github.com/containerd/containerd/reference/docker"
 	remotesdocker "github.com/containerd/containerd/remotes/docker"
+	"github.com/docker/go-units"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -162,6 +163,15 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 		} else {
 			opts = append(opts, oci.WithHostNamespace(specs.PIDNamespace))
 		}
+	}
+
+	// Size of /dev/shm
+	if len(config.ShmSize) > 0 {
+		shmBytes, err := units.RAMInBytes(config.ShmSize)
+		if err != nil {
+			return nil, fmt.Errorf("Error in setting shm_size: %v", err)
+		}
+		opts = append(opts, oci.WithDevShmSize(shmBytes/1024))
 	}
 
 	// Set sysctls

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -118,6 +118,7 @@ var (
 		"entrypoint":      hclspec.NewAttr("entrypoint", "list(string)", false),
 		"seccomp":         hclspec.NewAttr("seccomp", "bool", false),
 		"seccomp_profile": hclspec.NewAttr("seccomp_profile", "string", false),
+		"shm_size":        hclspec.NewAttr("shm_size", "string", false),
 		"sysctl":          hclspec.NewAttr("sysctl", "list(map(string))", false),
 		"readonly_rootfs": hclspec.NewAttr("readonly_rootfs", "bool", false),
 		"host_network":    hclspec.NewAttr("host_network", "bool", false),
@@ -183,6 +184,7 @@ type TaskConfig struct {
 	Devices          []string           `codec:"devices"`
 	Seccomp          bool               `codec:"seccomp"`
 	SeccompProfile   string             `codec:"seccomp_profile"`
+	ShmSize          string             `codec:"shm_size"`
 	Sysctl           hclutils.MapStrStr `codec:"sysctl"`
 	Privileged       bool               `codec:"privileged"`
 	PidsLimit        int64              `codec:"pids_limit"`

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200330121334-7f8b4b621b5d+incompatible
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
+	github.com/docker/go-units v0.4.0
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/hashicorp/consul-template v0.25.1


### PR DESCRIPTION
Equivalent docker option: https://www.nomadproject.io/docs/drivers/docker#shm_size

`shm_size` in `nomad-driver-containerd` is of type `string` (which is different from Docker task driver `shm_size` where it's a `number`). The reason for that is Docker task driver `shm_size` doesn't accept human readable sizes e.g. if you want to set your `/dev/shm` to `512MB` you need to set `shm_size=536870912`

In `containerd-driver` you can just set `shm_size="512M"`

Signed-off-by: Shishir Mahajan <smahajan@roblox.com>