### PR TITLE
Add support for terminal resizing in alloc exec

### DIFF
--- a/containerd/handle.go
+++ b/containerd/handle.go
@@ -143,6 +143,20 @@ func (h *taskHandle) exec(ctx, ctxContainerd context.Context, taskID string, opt
 	if err != nil {
 		return nil, err
 	}
+	go func() {
+		for {
+			select {
+			case s, ok := <-opts.ResizeCh:
+				if !ok {
+					return
+				}
+				if err = h.task.Resize(ctxContainerd, uint32(s.Width), uint32(s.Height)); err != nil {
+					h.logger.Error("Failed to resize terminal", "error", err)
+					return
+				}
+                        }
+		}
+	}()
 
 	defer process.Delete(ctxContainerd)
 


### PR DESCRIPTION
**Issue this is fixing**
Resizing the window breaks `alloc exec` stdin for interactive commands with an allocated pseudo-tty.

**How to reproduce the issue this is fixing**

1. Run
```
$ vagrant up
$ vagrant ssh
$ nomad job run example/hello.nomad
$ nomad exec -e @ -job hello /bin/bash
$ hostname
```
2. Resize your terminal window
1. Notice that your stdin is broken and you can't type the following command
```
$ hostname
```

Your only way out at this point is to hit `ENTER`, `@` and `.`