### PR TITLE
Bump version to 0.9.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nomad-driver-containerd
 [![CI Actions Status](https://github.com/Roblox/nomad-driver-containerd/workflows/CI/badge.svg)](https://github.com/Roblox/nomad-driver-containerd/actions)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Roblox/nomad-driver-containerd/blob/master/LICENSE)
-[![Release](https://img.shields.io/badge/version-0.9-blue)](https://github.com/Roblox/nomad-driver-containerd/releases/tag/v0.9)
+[![Release](https://img.shields.io/badge/version-0.9.1-blue)](https://github.com/Roblox/nomad-driver-containerd/releases/tag/v0.9.1)
 [![Docs](https://img.shields.io/badge/docs-website-green.svg)](https://www.nomadproject.io/docs/drivers/external/containerd)
 
 <img src="images/nomad.png" width="232" height="100" />&nbsp;<img src="images/docker.png" width="116" height="100" />&nbsp;<img src="images/containerd.png" width="285" height="100" />

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -47,7 +47,7 @@ const (
 
 	// PluginVersion allows the client to identify and use newer versions of
 	// an installed plugin
-	PluginVersion = "v0.9.0"
+	PluginVersion = "v0.9.1"
 
 	// fingerprintPeriod is the interval at which the plugin will send
 	// fingerprint responses


### PR DESCRIPTION
Changelog between 0.9 and 0.9.1:
```
$ git log v0.9..v0.9.1 --pretty=format:"%h %s"
84aa20f Bump version to 0.9.1.
1c443d6 Merge pull request #106 from Roblox/security_fix
0ec114b Upgrade containerd to 1.4.8.
fed7fbd Merge pull request #104 from Roblox/jamesalbert-patch-1
117ec3b image size adjustments
6e15035 Merge pull request #102 from Roblox/nerdctl
496e2d3 Add nerdctl to vagrant VM.
18db886 Merge pull request #101 from th0m/tlefebvre/add-terminal-resizing-support
24a7108 Add support for terminal resizing in alloc exec
```