### PR TITLE
Enable all devices in privileged mode

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -149,7 +149,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 
 	// Enable privileged mode.
 	if config.Privileged {
-		opts = append(opts, oci.WithPrivileged, oci.WithAllDevicesAllowed, oci.WithHostDevices)
+		opts = append(opts, oci.WithPrivileged, oci.WithAllDevicesAllowed, oci.WithHostDevices, oci.WithNewPrivileges)
 	}
 
 	// WithPidsLimit sets the container's pid limit or maximum

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -149,7 +149,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 
 	// Enable privileged mode.
 	if config.Privileged {
-		opts = append(opts, oci.WithPrivileged)
+		opts = append(opts, oci.WithPrivileged, oci.WithAllDevicesAllowed, oci.WithHostDevices)
 	}
 
 	// WithPidsLimit sets the container's pid limit or maximum

--- a/tests/004-test-privileged.sh
+++ b/tests/004-test-privileged.sh
@@ -41,7 +41,7 @@ test_privileged_nomad_job() {
     # depending on the execution environment.
     expected_capabilities="37"
     if [[ "$GITHUB_ACTIONS" == "true" ]]; then
-       expected_capabilities="39"
+       expected_capabilities="40"
     fi
 
     actual_capabilities=$(nomad alloc exec -job privileged capsh --print|grep -i bounding|cut -d '=' -f 2|awk '{split($0,a,","); print a[length(a)]}')


### PR DESCRIPTION
The Privileged mode in containerd driver is not adding devices from host device.

This change will make the driver's privileged mode equivalent to ctr tool's privileged mode - https://github.com/containerd/containerd/blob/main/cmd/ctr/commands/run/run_unix.go#L205-L207