### PR TITLE
fix entrypoint override

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -137,6 +137,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 
 	if config.Entrypoint != nil {
 		// WithProcessArgs replaces the args on the generated spec.
+		opts = append(opts, oci.WithImageConfig(containerConfig.Image))
 		opts = append(opts, oci.WithProcessArgs(args...))
 	} else {
 		// WithImageConfigArgs configures the spec to from the configuration of an Image

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -136,8 +136,8 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 	var opts []oci.SpecOpts
 
 	if config.Entrypoint != nil {
-		// WithProcessArgs replaces the args on the generated spec.
 		opts = append(opts, oci.WithImageConfig(containerConfig.Image))
+		// WithProcessArgs replaces the args on the generated spec.
 		opts = append(opts, oci.WithProcessArgs(args...))
 	} else {
 		// WithImageConfigArgs configures the spec to from the configuration of an Image


### PR DESCRIPTION
If the entrypoint is overriden, imageconfig needs to be passed, otherwise the container ignores the ENV,USER,etc params set in the image.

to reproduce the incorrect behavior run an image where there is a USER set in the image level, override the entrypoint, it will result a container running as root