### PR TITLE
Security fix: Upgrade nomad to 1.1.12.

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -12,6 +12,16 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run containerd-driver integration tests
         run: |
+          # Remove older version of golang.
+          sudo rm -f /usr/bin/go
+
+          # Install golang-1.17
+          export PATH=$PATH:/usr/local/go/bin
+          curl -s -L -o go1.17.linux-amd64.tar.gz https://dl.google.com/go/go1.17.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
+          sudo chmod +x /usr/local/go
+          rm -f go1.17.linux-amd64.tar.gz
+
           mkdir -p /home/runner/go/src/github.com/Roblox
           ln -s /home/runner/work/nomad-driver-containerd/nomad-driver-containerd /home/runner/go/src/github.com/Roblox/nomad-driver-containerd
           cd /home/runner/go/src/github.com/Roblox/nomad-driver-containerd

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,12 +36,12 @@ Vagrant.configure("2") do |config|
       rm -f go1.17.linux-amd64.tar.gz
     fi
 
-    # Install nomad-1.1.4
+    # Install nomad-1.1.12
     if [ ! -f "/usr/bin/nomad" ]; then
-      wget --quiet https://releases.hashicorp.com/nomad/1.1.4/nomad_1.1.4_linux_amd64.zip
-      unzip nomad_1.1.4_linux_amd64.zip -d /usr/bin
+      wget --quiet https://releases.hashicorp.com/nomad/1.1.12/nomad_1.1.12_linux_amd64.zip
+      unzip nomad_1.1.12_linux_amd64.zip -d /usr/bin
       chmod +x /usr/bin/nomad
-      rm -f nomad_1.1.4_linux_amd64.zip
+      rm -f nomad_1.1.12_linux_amd64.zip
     fi
 
     # Install containerd-1.5.5

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-envparse v0.0.0-20190703193109-150b3a2a4611 // indirect
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hashicorp/nomad v1.1.8
+	github.com/hashicorp/nomad v1.1.12
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ github.com/hashicorp/go-envparse v0.0.0-20190703193109-150b3a2a4611 h1:WdVEB9Qcc
 github.com/hashicorp/go-envparse v0.0.0-20190703193109-150b3a2a4611/go.mod h1:/NlxCzN2D4C4L2uDE6ux/h6jM+n98VFQM14nnCIfHJU=
 github.com/hashicorp/go-gatedio v0.5.0 h1:Jm1X5yP4yCqqWj5L1TgW7iZwCVPGtVc+mro5r/XX7Tg=
 github.com/hashicorp/go-gatedio v0.5.0/go.mod h1:Lr3t8L6IyxD3DAeaUxGcgl2JnRUpWMCsmBl4Omu/2t4=
-github.com/hashicorp/go-getter v1.5.4 h1:/A0xlardcuhx8SEe1rh1371xV7Yi4j3xeluu53VXeyg=
-github.com/hashicorp/go-getter v1.5.4/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
+github.com/hashicorp/go-getter v1.5.11 h1:wioTuNmaBU3IE9vdFtFMcmZWj0QzLc6DYaP6sNe5onY=
+github.com/hashicorp/go-getter v1.5.11/go.mod h1:9i48BP6wpWweI/0/+FBjqLrp9S8XtwUGjiu0QkWHEaY=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
@@ -717,8 +717,8 @@ github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.2.4 h1:OOhYzSvFnkFQXm1ysE8RjXTHsqSRDyP4emusC9K7DYg=
 github.com/hashicorp/memberlist v0.2.4/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69/go.mod h1:/z+jUGRBlwVpUZfjute9jWaF6/HuhjuFQuL1YXzVD1Q=
-github.com/hashicorp/nomad v1.1.8 h1:6VZ2DqvCuDRu0gzNNM7nOT5Ql46YMr+2zUuX4hoNhTY=
-github.com/hashicorp/nomad v1.1.8/go.mod h1:V7+6xpyhmj3FPu5IiZz44CpFIOFyHKSNy2jwLDqK0oE=
+github.com/hashicorp/nomad v1.1.12 h1:TZiG1JwwQy1wg1wxhtmeCFE3XWUj9WMyED7+ZGTRu9c=
+github.com/hashicorp/nomad v1.1.12/go.mod h1:icBVSWVwRr9o5buJf7hReujUtHj8paf45j5zNiRAmBw=
 github.com/hashicorp/nomad/api v0.0.0-20200529203653-c4416b26d3eb h1:gFssj9eV5on4ZYpwTQl+LTrkebu+qCxuKpISPcMCH88=
 github.com/hashicorp/nomad/api v0.0.0-20200529203653-c4416b26d3eb/go.mod h1:DCi2k47yuUDzf2qWAK8E1RVmWgz/lc0jZQeEnICTxmY=
 github.com/hashicorp/raft v1.1.1/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
@@ -826,6 +826,7 @@ github.com/likexian/gokit v0.0.0-20190309162924-0a377eecf7aa/go.mod h1:QdfYv6y6q
 github.com/likexian/gokit v0.0.0-20190418170008-ace88ad0983b/go.mod h1:KKqSnk/VVSW8kEyO2vVCXoanzEutKdlBAPohmGXkxCk=
 github.com/likexian/gokit v0.0.0-20190501133040-e77ea8b19cdc/go.mod h1:3kvONayqCaj+UgrRZGpgfXzHdMYCAO0KAt4/8n0L57Y=
 github.com/likexian/gokit v0.20.16/go.mod h1:kn+nTv3tqh6yhor9BC4Lfiu58SmH8NmQ2PmEl+uM6nU=
+github.com/likexian/gokit v0.25.6/go.mod h1:q1LC+z3cBymJuE4oeiWiIPhJceUa0nptg4Id8tSzjZI=
 github.com/likexian/simplejson-go v0.0.0-20190409170913-40473a74d76d/go.mod h1:Typ1BfnATYtZ/+/shXfFYLrovhFyuKvzwrdOnIDHlmg=
 github.com/likexian/simplejson-go v0.0.0-20190419151922-c1f9f0b4f084/go.mod h1:U4O1vIJvIKwbMZKUJ62lppfdvkCdVd2nfMimHK81eec=
 github.com/likexian/simplejson-go v0.0.0-20190502021454-d8787b4bfa0b/go.mod h1:3BWwtmKP9cXWwYCr5bkoVDEfLywacOv0s06OBEDpyt8=

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-export NOMAD_VERSION=1.1.4
+export NOMAD_VERSION=1.1.12
 export CONTAINERD_VERSION=1.5.5
 export PATH=$PATH:/usr/local/go/bin
 export PATH=$PATH:/usr/local/bin
@@ -131,7 +131,7 @@ EOF
 	sudo chmod +x /usr/local/go
 	rm -f go${GO_VERSION}.linux-amd64.tar.gz
 
-	# Install nomad 1.1.4
+	# Install nomad 1.1.12
 	curl -L -o nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip
 	sudo unzip -d /usr/local/bin nomad_${NOMAD_VERSION}_linux_amd64.zip
 	sudo chmod +x /usr/local/bin/nomad


### PR DESCRIPTION
Fixes `CVE-2022-24683`

Signed-off-by: Shishir Mahajan <smahajan@roblox.com>