### PR TITLE
Add support for cpuset_cpus and cpuset_mems

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ To interact with `images` and `containers` directly, you can use [`nerdctl`](htt
 | **extra_hosts** | []string | no | A list of hosts, given as host:IP, to be added to /etc/hosts. |
 | **cap_add** | []string | no | Add individual capabilities. |
 | **cap_drop** | []string | no | Drop invidual capabilities. |
+| **cpuset_cpus** | string | no | CPUs in which to allow execution (0-3, 0,1). |
+| **cpuset_mems** | string | no | MEMs in which to allow execution (0-3, 0,1). |
 | **devices** | []string | no | A list of devices to be exposed to the container. |
 | **auth** | block | no | Provide authentication for a private registry. See [Authentication](#authentication-private-registry) for more details. |
 | **mounts** | []block | no | A list of mounts to be mounted in the container. Volume, bind and tmpfs type mounts are supported. fstab style [`mount options`](https://github.com/containerd/containerd/blob/master/mount/mount_linux.go#L211-L235) are supported. |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
 # Create box
 Vagrant.configure("2") do |config|
   config.vm.define "containerd-linux"
-  config.vm.box = "hashicorp/bionic64"
+  config.vm.box = "generic/ubuntu2204"
   config.vm.provider "libvirt" do |v, override|
     override.vm.box = "generic/debian10"
     override.vm.synced_folder ".", "/home/vagrant/go/src/github.com/Roblox/nomad-driver-containerd", type: "nfs", nfs_version: 4, nfs_udp: false
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
-    apt-get install -y unzip gcc runc jq
+    apt-get install -y unzip gcc runc jq make
     echo "export GOPATH=/home/vagrant/go" >> /home/vagrant/.bashrc
     echo "export PATH=$PATH:/usr/local/go/bin" >> /home/vagrant/.bashrc
     echo "export CONTAINERD_NAMESPACE=nomad" >> /home/vagrant/.bashrc

--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -217,6 +217,18 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 		opts = append(opts, oci.WithDroppedCapabilities(config.CapDrop))
 	}
 
+	// This translates to docker create/run --cpuset-cpus option.
+	// --cpuset-cpus limit the specific CPUs or cores a container can use.
+	if config.CPUSetCPUs != "" {
+		opts = append(opts, oci.WithCPUs(config.CPUSetCPUs))
+	}
+
+	// --cpuset-mems is the list of memory nodes on which processes
+	// in this cpuset are allowed to allocate memory.
+	if config.CPUSetMEMs != "" {
+		opts = append(opts, oci.WithCPUsMems(config.CPUSetMEMs))
+	}
+
 	// Set current working directory (cwd).
 	if config.Cwd != "" {
 		opts = append(opts, oci.WithProcessCwd(config.Cwd))

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -96,17 +96,19 @@ var (
 	// this is used to validate the configuration specified for the plugin
 	// when a job is submitted.
 	taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
-		"image":      hclspec.NewAttr("image", "string", true),
-		"command":    hclspec.NewAttr("command", "string", false),
-		"args":       hclspec.NewAttr("args", "list(string)", false),
-		"cap_add":    hclspec.NewAttr("cap_add", "list(string)", false),
-		"cap_drop":   hclspec.NewAttr("cap_drop", "list(string)", false),
-		"cwd":        hclspec.NewAttr("cwd", "string", false),
-		"devices":    hclspec.NewAttr("devices", "list(string)", false),
-		"privileged": hclspec.NewAttr("privileged", "bool", false),
-		"pids_limit": hclspec.NewAttr("pids_limit", "number", false),
-		"pid_mode":   hclspec.NewAttr("pid_mode", "string", false),
-		"hostname":   hclspec.NewAttr("hostname", "string", false),
+		"image":       hclspec.NewAttr("image", "string", true),
+		"command":     hclspec.NewAttr("command", "string", false),
+		"args":        hclspec.NewAttr("args", "list(string)", false),
+		"cap_add":     hclspec.NewAttr("cap_add", "list(string)", false),
+		"cap_drop":    hclspec.NewAttr("cap_drop", "list(string)", false),
+		"cpuset_cpus": hclspec.NewAttr("cpuset_cpus", "string", false),
+		"cpuset_mems": hclspec.NewAttr("cpuset_mems", "string", false),
+		"cwd":         hclspec.NewAttr("cwd", "string", false),
+		"devices":     hclspec.NewAttr("devices", "list(string)", false),
+		"privileged":  hclspec.NewAttr("privileged", "bool", false),
+		"pids_limit":  hclspec.NewAttr("pids_limit", "number", false),
+		"pid_mode":    hclspec.NewAttr("pid_mode", "string", false),
+		"hostname":    hclspec.NewAttr("hostname", "string", false),
 		"host_dns": hclspec.NewDefault(
 			hclspec.NewAttr("host_dns", "bool", false),
 			hclspec.NewLiteral("true"),
@@ -181,6 +183,8 @@ type TaskConfig struct {
 	Args             []string           `codec:"args"`
 	CapAdd           []string           `codec:"cap_add"`
 	CapDrop          []string           `codec:"cap_drop"`
+	CPUSetCPUs       string             `codec:"cpuset_cpus"`
+	CPUSetMEMs       string             `codec:"cpuset_mems"`
 	Cwd              string             `codec:"cwd"`
 	Devices          []string           `codec:"devices"`
 	Seccomp          bool               `codec:"seccomp"`

--- a/example/redis.nomad
+++ b/example/redis.nomad
@@ -6,10 +6,12 @@ job "redis" {
       driver = "containerd-driver"
 
       config {
-        image    = "redis:alpine"
-        hostname = "foobar"
-        seccomp  = true
-        cwd      = "/home/redis"
+        image       = "redis:alpine"
+        hostname    = "foobar"
+        seccomp     = true
+        cwd         = "/home/redis"
+        cpuset_cpus = "0-1"
+        cpuset_mems = "0"
       }
 
       resources {


### PR DESCRIPTION
- This will add support for CPU and Memory pinning in nomad containerd-driver.
- This is equivalent to the following docker create/run options.

```
--cpuset-cpus string             CPUs in which to allow execution (0-3, 0,1)
--cpuset-mems string             MEMs in which to allow execution (0-3, 0,1)
```