### PR TITLE
Fix error messages to follow Go conventions

### DIFF
--- a/containerd/containerd.go
+++ b/containerd/containerd.go
@@ -96,7 +96,7 @@ func withResolver(creds CredentialsOpt) containerd.RemoteOpt {
 func (d *Driver) pullImage(imageName, imagePullTimeout string, auth *RegistryAuth) (containerd.Image, error) {
 	pullTimeout, err := time.ParseDuration(imagePullTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse image_pull_timeout: %v", err)
+		return nil, fmt.Errorf("failed to parse image_pull_timeout: %v", err)
 	}
 
 	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, pullTimeout)
@@ -117,7 +117,7 @@ func (d *Driver) pullImage(imageName, imagePullTimeout string, auth *RegistryAut
 
 func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskConfig) (containerd.Container, error) {
 	if config.Command != "" && config.Entrypoint != nil {
-		return nil, fmt.Errorf("Both command and entrypoint are set. Only one of them needs to be set.")
+		return nil, fmt.Errorf("both command and entrypoint are set. Only one of them needs to be set")
 	}
 
 	// Entrypoint or Command set by the user, to override entrypoint or cmd defined in the image.
@@ -146,7 +146,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 	}
 
 	if !d.config.AllowPrivileged && config.Privileged {
-		return nil, fmt.Errorf("Running privileged jobs are not allowed. Set allow_privileged to true in plugin config to allow running privileged jobs.")
+		return nil, fmt.Errorf("running privileged jobs are not allowed. Set allow_privileged to true in plugin config to allow running privileged jobs")
 	}
 
 	// Enable privileged mode.
@@ -161,7 +161,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 
 	if config.PidMode != "" {
 		if strings.ToLower(config.PidMode) != "host" {
-			return nil, fmt.Errorf("Invalid pid_mode. Set pid_mode=host to enable host pid namespace.")
+			return nil, fmt.Errorf("invalid pid_mode. Set pid_mode=host to enable host pid namespace")
 		} else {
 			opts = append(opts, oci.WithHostNamespace(specs.PIDNamespace))
 		}
@@ -171,7 +171,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 	if len(config.ShmSize) > 0 {
 		shmBytes, err := units.RAMInBytes(config.ShmSize)
 		if err != nil {
-			return nil, fmt.Errorf("Error in setting shm_size: %v", err)
+			return nil, fmt.Errorf("error in setting shm_size: %v", err)
 		}
 		opts = append(opts, oci.WithDevShmSize(shmBytes/1024))
 	}
@@ -182,7 +182,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 	}
 
 	if !config.Seccomp && config.SeccompProfile != "" {
-		return nil, fmt.Errorf("seccomp must be set to true, if using a custom seccomp_profile.")
+		return nil, fmt.Errorf("seccomp must be set to true, if using a custom seccomp_profile")
 	}
 
 	// Enable default (or custom) seccomp profile.
@@ -249,7 +249,7 @@ func (d *Driver) createContainer(containerConfig *ContainerConfig, config *TaskC
 	mounts := make([]specs.Mount, 0)
 	for _, mount := range config.Mounts {
 		if (mount.Type == "bind" || mount.Type == "volume") && len(mount.Options) <= 0 {
-			return nil, fmt.Errorf("Options cannot be empty for mount type: %s. You need to atleast pass rbind and ro.", mount.Type)
+			return nil, fmt.Errorf("options cannot be empty for mount type: %s. You need to atleast pass rbind and ro", mount.Type)
 		}
 
 		// Allow paths relative to $NOMAD_TASK_DIR.

--- a/containerd/driver.go
+++ b/containerd/driver.go
@@ -447,7 +447,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	var err error
 	containerConfig.Image, err = d.pullImage(driverConfig.Image, driverConfig.ImagePullTimeout, &driverConfig.Auth)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error in pulling image %s: %v", driverConfig.Image, err)
+		return nil, nil, fmt.Errorf("error in pulling image %s: %v", driverConfig.Image, err)
 	}
 
 	d.logger.Info(fmt.Sprintf("Successfully pulled %s image\n", containerConfig.Image.Name()))
@@ -485,13 +485,13 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 
 	container, err := d.createContainer(&containerConfig, &driverConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error in creating container: %v", err)
+		return nil, nil, fmt.Errorf("error in creating container: %v", err)
 	}
 
 	d.logger.Info(fmt.Sprintf("Successfully created container with name: %s\n", containerName))
 	task, err := d.createTask(container, cfg.StdoutPath, cfg.StderrPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error in creating task: %v", err)
+		return nil, nil, fmt.Errorf("error in creating task: %v", err)
 	}
 
 	d.logger.Info(fmt.Sprintf("Successfully created task with ID: %s\n", task.ID()))
@@ -554,12 +554,12 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 
 	container, err := d.loadContainer(taskState.ContainerName)
 	if err != nil {
-		return fmt.Errorf("Error in recovering container: %v", err)
+		return fmt.Errorf("error in recovering container: %v", err)
 	}
 
 	task, err := d.getTask(container, taskState.StdoutPath, taskState.StderrPath)
 	if err != nil {
-		return fmt.Errorf("Error in recovering task: %v", err)
+		return fmt.Errorf("error in recovering task: %v", err)
 	}
 
 	ctxWithTimeout, cancel := context.WithTimeout(d.ctxContainerd, 30*time.Second)
@@ -567,7 +567,7 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 
 	status, err := task.Status(ctxWithTimeout)
 	if err != nil {
-		return fmt.Errorf("Error in recovering task status: %v", err)
+		return fmt.Errorf("error in recovering task status: %v", err)
 	}
 
 	h := &taskHandle{
@@ -644,7 +644,7 @@ func (d *Driver) StopTask(taskID string, timeout time.Duration, signal string) e
 	}
 
 	if err := handle.shutdown(d.ctxContainerd, timeout, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("Shutdown failed: %v", err)
+		return fmt.Errorf("shutdown failed: %v", err)
 	}
 
 	return nil
@@ -723,7 +723,7 @@ func (d *Driver) SignalTask(taskID string, signal string) error {
 	// for a list of supported signals.
 	sig, ok := signals.SignalLookup[signal]
 	if !ok {
-		return fmt.Errorf("Invalid signal: %s", signal)
+		return fmt.Errorf("invalid signal: %s", signal)
 	}
 
 	return handle.signal(d.ctxContainerd, sig)
@@ -743,5 +743,5 @@ func (d *Driver) ExecTaskStreaming(ctx context.Context, taskID string, opts *dri
 // This is an optional capability.
 func (d *Driver) ExecTask(taskID string, cmd []string, timeout time.Duration) (*drivers.ExecTaskResult, error) {
 	// TODO: implement driver specific logic to execute commands in a task.
-	return nil, fmt.Errorf("This driver does not support exec")
+	return nil, fmt.Errorf("this driver does not support exec")
 }

--- a/containerd/handle.go
+++ b/containerd/handle.go
@@ -93,7 +93,7 @@ func (h *taskHandle) IsRunning(ctxContainerd context.Context) (bool, error) {
 
 	status, err := h.task.Status(ctxWithTimeout)
 	if err != nil {
-		return false, fmt.Errorf("Error in getting task status: %v", err)
+		return false, fmt.Errorf("error in getting task status: %v", err)
 	}
 
 	return (status.Status == containerd.Running), nil
@@ -154,7 +154,7 @@ func (h *taskHandle) exec(ctx, ctxContainerd context.Context, taskID string, opt
 					h.logger.Error("Failed to resize terminal", "error", err)
 					return
 				}
-                        }
+			}
 		}
 	}()
 


### PR DESCRIPTION
https://go.dev/wiki/CodeReviewComments#error-strings

> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context.